### PR TITLE
Add audio output and basic audio controls to the Qt frontend

### DIFF
--- a/build-mac.sh
+++ b/build-mac.sh
@@ -1,0 +1,209 @@
+#!/bin/sh
+
+set -eu
+
+# macOS build helper. Keep this separate from build.sh so the default script
+# stays untouched.
+
+if [ "${BUILD_MAC_GIT_PULL:-0}" = "1" ] && [ -d ".git" ]; then
+	if ! git pull --recurse-submodules=yes; then
+		git pull --no-recurse-submodules
+	fi
+fi
+
+BUILD_MODE=Release
+BUILD_ROOT="${BUILD_ROOT:-build-ninja-m1}"
+QT6_DIR="${QT6_DIR:-/opt/homebrew/opt/qt/lib/cmake/Qt6}"
+ENABLE_OGLRENDERER="${ENABLE_OGLRENDERER:-OFF}"
+ENABLE_LTO_RELEASE="${ENABLE_LTO_RELEASE:-ON}"
+MELONDS_SRC_DIR="$(pwd)/melonds-rs/melonDS/src"
+
+if command -v ninja >/dev/null 2>&1; then
+	CORES_GENERATOR="Ninja"
+else
+	CORES_GENERATOR="Unix Makefiles"
+fi
+
+jobs() {
+	if command -v nproc >/dev/null 2>&1; then
+		nproc
+	elif command -v sysctl >/dev/null 2>&1; then
+		sysctl -n hw.physicalcpu
+	else
+		echo 4
+	fi
+}
+
+cmake_launcher_args() {
+	if command -v ccache >/dev/null 2>&1; then
+		printf '%s\n' \
+			-DCMAKE_C_COMPILER_LAUNCHER=ccache \
+			-DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+	fi
+}
+
+find_macdeployqt() {
+	if [ -n "${MACDEPLOYQT:-}" ] && [ -x "${MACDEPLOYQT}" ]; then
+		printf '%s\n' "${MACDEPLOYQT}"
+		return 0
+	fi
+
+	if command -v macdeployqt >/dev/null 2>&1; then
+		command -v macdeployqt
+		return 0
+	fi
+
+	qt_prefix=$(cd "${QT6_DIR}/../../.." && pwd)
+	if [ -x "${qt_prefix}/bin/macdeployqt" ]; then
+		printf '%s\n' "${qt_prefix}/bin/macdeployqt"
+		return 0
+	fi
+
+	return 1
+}
+
+bundle_sdl3() {
+	app="$1"
+	app_bin="${app}/Contents/MacOS/SuperShuckie"
+	frameworks_dir="${app}/Contents/Frameworks"
+	sdl_src=$(otool -L "${app_bin}" | awk '/libSDL3\.0\.dylib/{print $1; exit}')
+
+	if [ -z "${sdl_src}" ]; then
+		printf 'failed to locate linked SDL3 dylib in %s\n' "${app_bin}" >&2
+		exit 1
+	fi
+
+	case "${sdl_src}" in
+		@executable_path/*|@rpath/*)
+			return 0
+			;;
+	esac
+
+	mkdir -p "${frameworks_dir}"
+	cp -f "${sdl_src}" "${frameworks_dir}/libSDL3.0.dylib"
+	chmod u+w "${frameworks_dir}/libSDL3.0.dylib"
+	install_name_tool -id "@rpath/libSDL3.0.dylib" "${frameworks_dir}/libSDL3.0.dylib"
+	install_name_tool -change "${sdl_src}" "@executable_path/../Frameworks/libSDL3.0.dylib" "${app_bin}"
+}
+
+write_qt_conf() {
+	app="$1"
+	mkdir -p "${app}/Contents/Resources"
+	cat > "${app}/Contents/Resources/qt.conf" <<'EOF'
+[Paths]
+Plugins = PlugIns
+EOF
+}
+
+ad_hoc_sign_app() {
+	app="$1"
+	frameworks_dir="${app}/Contents/Frameworks"
+	plugins_dir="${app}/Contents/PlugIns"
+	app_bin="${app}/Contents/MacOS/SuperShuckie"
+
+	if ! command -v codesign >/dev/null 2>&1; then
+		return 0
+	fi
+
+	if [ -d "${frameworks_dir}" ]; then
+		find "${frameworks_dir}" -maxdepth 1 -type d -name '*.framework' -print | while IFS= read -r framework; do
+			codesign --force --sign - --timestamp=none "${framework}"
+		done
+		find "${frameworks_dir}" -maxdepth 1 -type f -name '*.dylib' -print | while IFS= read -r dylib; do
+			codesign --force --sign - --timestamp=none "${dylib}"
+		done
+	fi
+
+	if [ -d "${plugins_dir}" ]; then
+		find "${plugins_dir}" -type f -name '*.dylib' -print | while IFS= read -r plugin; do
+			codesign --force --sign - --timestamp=none "${plugin}"
+		done
+	fi
+
+	codesign --force --sign - --timestamp=none "${app_bin}"
+	codesign --force --sign - --timestamp=none "${app}"
+}
+
+verify_no_homebrew_refs() {
+	app="$1"
+	bad_refs=$(
+		find "${app}/Contents" -type f -print | while IFS= read -r file; do
+			if file "${file}" | grep -q 'Mach-O'; then
+				otool -L "${file}" 2>/dev/null | grep '/opt/homebrew' || true
+			fi
+		done
+	)
+
+	if [ -n "${bad_refs}" ]; then
+		printf 'unbundled Homebrew references remain:\n%s\n' "${bad_refs}" >&2
+		exit 1
+	fi
+}
+
+deploy_app_bundle() {
+	app="$1"
+	macdeployqt_bin=$(find_macdeployqt) || {
+		printf 'macdeployqt not found; install Qt deployment tools or set MACDEPLOYQT\n' >&2
+		exit 1
+	}
+
+	write_qt_conf "${app}"
+	"${macdeployqt_bin}" "${app}" -always-overwrite
+	bundle_sdl3 "${app}"
+	ad_hoc_sign_app "${app}"
+	verify_no_homebrew_refs "${app}"
+}
+
+if command -v ccache >/dev/null 2>&1; then
+	export CCACHE_DIR="${CCACHE_DIR:-/tmp/ccache-supershuckie}"
+	export CCACHE_TEMPDIR="${CCACHE_TEMPDIR:-$CCACHE_DIR/tmp}"
+	mkdir -p "$CCACHE_DIR" "$CCACHE_TEMPDIR"
+fi
+
+export RUSTFLAGS="${RUSTFLAGS:--C target-cpu=apple-m1}"
+
+CMAKE_C_FLAGS_RELEASE="-O3 -mcpu=apple-m1"
+CMAKE_CXX_FLAGS_RELEASE="-O3 -mcpu=apple-m1"
+
+cmake -S ./melonds-rs/melonDS -B "${BUILD_ROOT}/melonDS" -G "$CORES_GENERATOR" \
+	-DENABLE_JIT=ON \
+	-DENABLE_OGLRENDERER="$ENABLE_OGLRENDERER" \
+	-DENABLE_GDBSTUB=OFF \
+	-DBUILD_QT_SDL=OFF \
+	-DENABLE_LTO_RELEASE="$ENABLE_LTO_RELEASE" \
+	-DCMAKE_BUILD_TYPE="$BUILD_MODE" \
+	-DCMAKE_OSX_ARCHITECTURES=arm64 \
+	-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
+	$(cmake_launcher_args) \
+	"-DCMAKE_CXX_FLAGS=-I${MELONDS_SRC_DIR}" \
+	"-DCMAKE_C_FLAGS_RELEASE=$CMAKE_C_FLAGS_RELEASE" \
+	"-DCMAKE_CXX_FLAGS_RELEASE=$CMAKE_CXX_FLAGS_RELEASE"
+cmake --build "${BUILD_ROOT}/melonDS" -j"$(jobs)"
+
+cmake -S ./mgba-rs/mgba -B "${BUILD_ROOT}/mgba" -G "$CORES_GENERATOR" \
+	-DLIBMGBA_ONLY=ON \
+	-DDISABLE_FRONTENDS=ON \
+	-DCMAKE_BUILD_TYPE="$BUILD_MODE" \
+	-DCMAKE_OSX_ARCHITECTURES=arm64 \
+	-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
+	$(cmake_launcher_args) \
+	"-DCMAKE_C_FLAGS_RELEASE=$CMAKE_C_FLAGS_RELEASE" \
+	"-DCMAKE_CXX_FLAGS_RELEASE=$CMAKE_CXX_FLAGS_RELEASE"
+cmake --build "${BUILD_ROOT}/mgba" -j"$(jobs)"
+
+cmake -S ./supershuckie-qt -B "${BUILD_ROOT}" -G "$CORES_GENERATOR" \
+	-DCMAKE_BUILD_TYPE="$BUILD_MODE" \
+	-DSCRIPT_BUILD=ON \
+	-DQt6_DIR="$QT6_DIR" \
+	-DCMAKE_IGNORE_PATH=/usr/local \
+	-DCMAKE_OSX_ARCHITECTURES=arm64 \
+	-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
+	$(cmake_launcher_args) \
+	"-DCMAKE_C_FLAGS_RELEASE=$CMAKE_C_FLAGS_RELEASE" \
+	"-DCMAKE_CXX_FLAGS_RELEASE=$CMAKE_CXX_FLAGS_RELEASE"
+cmake --build "${BUILD_ROOT}" -j"$(jobs)"
+
+deploy_app_bundle "${BUILD_ROOT}/SuperShuckie.app"
+
+mkdir -p dist/macos
+ditto "${BUILD_ROOT}/SuperShuckie.app" dist/macos/SuperShuckie.app

--- a/melonds-rs/interface.cpp
+++ b/melonds-rs/interface.cpp
@@ -2,6 +2,7 @@
 
 #include "melonDS/src/NDS.h"
 #include "melonDS/src/Platform.h"
+#include <cstdint>
 #include <cstdlib>
 #include <memory>
 #include <semaphore>
@@ -12,6 +13,7 @@ static u64 ms;
 
 struct MelonDSCoreHolder {
     std::unique_ptr<NDS> nds;
+    double audio_sample_rate = 48000.0;
 };
 
 extern "C" MelonDSCoreHolder *melonds_rs_core_new(
@@ -53,6 +55,7 @@ extern "C" MelonDSCoreHolder *melonds_rs_core_new(
     holder->nds->LoadBIOS();
     holder->nds->SetupDirectBoot("nds.rom");
     holder->nds->Start();
+    holder->nds->SPU.SetOutputSampleRate(holder->audio_sample_rate);
 
     return holder;
 }
@@ -63,6 +66,18 @@ extern "C" void melonds_rs_core_free(MelonDSCoreHolder *core) {
 
 extern "C" void melonds_rs_core_run_frame(MelonDSCoreHolder *core) {
     core->nds->RunFrame();
+}
+
+extern "C" unsigned melonds_rs_core_audio_sample_rate(const MelonDSCoreHolder *core) {
+    return static_cast<unsigned>(core->audio_sample_rate);
+}
+
+extern "C" int melonds_rs_core_audio_available(MelonDSCoreHolder *core) {
+    return core->nds->SPU.GetOutputSize();
+}
+
+extern "C" int melonds_rs_core_audio_read(MelonDSCoreHolder *core, std::int16_t *out, int samples) {
+    return core->nds->SPU.ReadOutput(out, samples);
 }
 
 extern "C" u8 *melonds_rs_core_get_sram(const MelonDSCoreHolder *core, size_t &size) {

--- a/melonds-rs/src/lib.rs
+++ b/melonds-rs/src/lib.rs
@@ -23,6 +23,9 @@ unsafe extern "C" {
     fn melonds_rs_core_create_save_state(core: *const MelonDSCoreHolderRaw, data: *mut u8, data_size: usize) -> usize;
     fn melonds_rs_core_load_save_state(core: *mut MelonDSCoreHolderRaw, data: *const u8, data_size: usize) -> bool;
     fn melonds_rs_core_get_ram(core: *mut MelonDSCoreHolderRaw) -> *mut [u8; 0x400000];
+    fn melonds_rs_core_audio_sample_rate(core: *const MelonDSCoreHolderRaw) -> u32;
+    fn melonds_rs_core_audio_available(core: *mut MelonDSCoreHolderRaw) -> i32;
+    fn melonds_rs_core_audio_read(core: *mut MelonDSCoreHolderRaw, out: *mut i16, samples: i32) -> i32;
     fn melonds_rs_core_set_date(
         core: *mut MelonDSCoreHolderRaw,
         year: u16,
@@ -101,6 +104,26 @@ impl Core {
     #[inline]
     pub fn get_main_ram_mut(&mut self) -> &mut [u8] {
         unsafe { &mut *melonds_rs_core_get_ram(self.inner) }.as_mut_slice()
+    }
+
+    #[inline]
+    pub fn audio_sample_rate(&self) -> u32 {
+        unsafe { melonds_rs_core_audio_sample_rate(self.inner) }
+    }
+
+    #[inline]
+    pub fn audio_available_samples(&mut self) -> usize {
+        unsafe { melonds_rs_core_audio_available(self.inner) }.max(0) as usize
+    }
+
+    #[inline]
+    pub fn read_audio(&mut self, out: &mut [i16]) -> usize {
+        let frames = (out.len() / 2) as i32;
+        if frames <= 0 {
+            return 0;
+        }
+        let read = unsafe { melonds_rs_core_audio_read(self.inner, out.as_mut_ptr(), frames) };
+        read.max(0) as usize
     }
 
     #[inline]

--- a/mgba-rs/interface.cpp
+++ b/mgba-rs/interface.cpp
@@ -10,6 +10,7 @@
 #include <mgba/core/core.h>
 #include <mgba/core/log.h>
 #include <mgba/core/serialize.h>
+#include <mgba-util/audio-buffer.h>
 #include <mgba-util/vfs.h>
 #include <mgba/gba/core.h>
 
@@ -134,6 +135,26 @@ extern "C" void mgba_rs_core_run_frame(MGBACoreRaw *core) {
 
 extern "C" void mgba_rs_core_reset(MGBACoreRaw *core) {
     core->core->reset(core->core);
+}
+
+extern "C" unsigned mgba_rs_core_audio_sample_rate(const MGBACoreRaw *core) {
+    return core->core->audioSampleRate(core->core);
+}
+
+extern "C" std::size_t mgba_rs_core_audio_available(MGBACoreRaw *core) {
+    auto *buffer = core->core->getAudioBuffer(core->core);
+    if(buffer == nullptr) {
+        return 0;
+    }
+    return mAudioBufferAvailable(buffer);
+}
+
+extern "C" std::size_t mgba_rs_core_audio_read(MGBACoreRaw *core, std::int16_t *out, std::size_t samples) {
+    auto *buffer = core->core->getAudioBuffer(core->core);
+    if(buffer == nullptr || samples == 0) {
+        return 0;
+    }
+    return mAudioBufferRead(buffer, out, samples);
 }
 
 extern "C" const std::uint32_t *mgba_rs_core_get_pixels(const MGBACoreRaw *core) {

--- a/mgba-rs/src/lib.rs
+++ b/mgba-rs/src/lib.rs
@@ -25,6 +25,9 @@ unsafe extern "C" {
     fn mgba_rs_core_load_save_state(core: *mut MGBACoreRaw, data: *const u8, data_size: usize) -> bool;
     fn mgba_rs_core_get_ewram(core: *mut MGBACoreRaw) -> *mut [u8; 0x40000];
     fn mgba_rs_core_get_iwram(core: *mut MGBACoreRaw) -> *mut [u8; 0x8000];
+    fn mgba_rs_core_audio_sample_rate(core: *const MGBACoreRaw) -> u32;
+    fn mgba_rs_core_audio_available(core: *mut MGBACoreRaw) -> usize;
+    fn mgba_rs_core_audio_read(core: *mut MGBACoreRaw, out: *mut i16, samples: usize) -> usize;
 }
 
 pub struct Core {
@@ -107,6 +110,25 @@ impl Core {
     #[inline]
     pub fn get_iwram_mut(&mut self) -> &mut [u8] {
         unsafe { &mut *mgba_rs_core_get_iwram(self.inner) }.as_mut_slice()
+    }
+
+    #[inline]
+    pub fn audio_sample_rate(&self) -> u32 {
+        unsafe { mgba_rs_core_audio_sample_rate(self.inner) }
+    }
+
+    #[inline]
+    pub fn audio_available_samples(&mut self) -> usize {
+        unsafe { mgba_rs_core_audio_available(self.inner) }
+    }
+
+    #[inline]
+    pub fn read_audio(&mut self, out: &mut [i16]) -> usize {
+        let frames = out.len() / 2;
+        if frames == 0 {
+            return 0;
+        }
+        unsafe { mgba_rs_core_audio_read(self.inner, out.as_mut_ptr(), frames) }
     }
 }
 

--- a/supershuckie-core/src/emulator.rs
+++ b/supershuckie-core/src/emulator.rs
@@ -83,6 +83,23 @@ pub trait EmulatorCore: Send + 'static {
 
     /// Get the current core name.
     fn core_name(&self) -> &'static str;
+
+    /// Get the audio sample rate, if supported.
+    fn audio_sample_rate(&self) -> Option<u32> {
+        None
+    }
+
+    /// Get the number of available stereo audio frames, if supported.
+    fn audio_available_samples(&mut self) -> usize {
+        0
+    }
+
+    /// Read interleaved stereo audio samples into `out`.
+    ///
+    /// Returns the number of frames written.
+    fn read_audio(&mut self, _out: &mut [i16]) -> usize {
+        0
+    }
     
     /// Return true if the core is a null core.
     #[inline]

--- a/supershuckie-core/src/emulator/game_boy_advance.rs
+++ b/supershuckie-core/src/emulator/game_boy_advance.rs
@@ -120,6 +120,18 @@ impl EmulatorCore for GameBoyAdvance {
         self.core.get_sram().to_vec()
     }
 
+    fn audio_sample_rate(&self) -> Option<u32> {
+        Some(self.core.audio_sample_rate())
+    }
+
+    fn audio_available_samples(&mut self) -> usize {
+        self.core.audio_available_samples()
+    }
+
+    fn read_audio(&mut self, out: &mut [i16]) -> usize {
+        self.core.read_audio(out)
+    }
+
     #[inline]
     fn create_save_state(&self) -> Vec<u8> {
         self.core.create_save_state().expect("failed to create GBA save state")

--- a/supershuckie-core/src/emulator/nintendo_ds.rs
+++ b/supershuckie-core/src/emulator/nintendo_ds.rs
@@ -121,6 +121,18 @@ impl EmulatorCore for NintendoDS {
         self.core.get_sram().to_vec()
     }
 
+    fn audio_sample_rate(&self) -> Option<u32> {
+        Some(self.core.audio_sample_rate())
+    }
+
+    fn audio_available_samples(&mut self) -> usize {
+        self.core.audio_available_samples()
+    }
+
+    fn read_audio(&mut self, out: &mut [i16]) -> usize {
+        self.core.read_audio(out)
+    }
+
     fn create_save_state(&self) -> Vec<u8> {
         self.core.create_save_state().expect("failed to make NDS save state???")
     }

--- a/supershuckie-core/src/lib.rs
+++ b/supershuckie-core/src/lib.rs
@@ -165,6 +165,23 @@ impl SuperShuckieCore {
         self.replay_counters.as_ref()
     }
 
+    /// Get the audio sample rate, if supported.
+    pub fn audio_sample_rate(&self) -> Option<u32> {
+        self.core.audio_sample_rate()
+    }
+
+    /// Get the number of available stereo audio frames, if supported.
+    pub fn audio_available_samples(&mut self) -> usize {
+        self.core.audio_available_samples()
+    }
+
+    /// Read interleaved stereo audio samples into `out`.
+    ///
+    /// Returns the number of frames written.
+    pub fn read_audio(&mut self, out: &mut [i16]) -> usize {
+        self.core.read_audio(out)
+    }
+
     fn do_run_fn(&mut self, run_fn: fn(&mut dyn EmulatorCore) -> RunTime) {
         if !self.replay_stalled {
             self.before_run();

--- a/supershuckie-core/src/thread.rs
+++ b/supershuckie-core/src/thread.rs
@@ -4,7 +4,7 @@ use crate::{SuperShuckieCore, SuperShuckieRapidFire};
 use spin::RwLock;
 use std::borrow::ToOwned;
 use std::boxed::Box;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::format;
 use std::fs::File;
 use std::string::String;
@@ -37,7 +37,9 @@ pub struct ThreadedSuperShuckieCore {
     playback_total_frames: UnsignedInteger,
     playback_total_milliseconds: TimestampMillis,
     replay_errors: Arc<Mutex<Vec<ReplayFileWriteError>>>,
-    replay_counters: Arc<Mutex<BTreeMap<String, SignedInteger>>>
+    replay_counters: Arc<Mutex<BTreeMap<String, SignedInteger>>>,
+    audio_buffer: Arc<Mutex<AudioBuffer>>,
+    audio_sample_rate: Arc<AtomicU32>,
 }
 
 /// Current elapsed time, retrieved atomically (the frame count corresponds to milliseconds and vice versa).
@@ -49,12 +51,67 @@ pub struct ElapsedTimeStats {
     pub speed: Speed
 }
 
+struct AudioBuffer {
+    data: VecDeque<i16>,
+    max_samples: usize,
+}
+
+impl AudioBuffer {
+    fn new(max_samples: usize) -> Self {
+        Self {
+            data: VecDeque::new(),
+            max_samples: max_samples.max(2) & !1,
+        }
+    }
+
+    fn set_max_samples(&mut self, max_samples: usize) {
+        self.max_samples = (max_samples.max(2) & !1).max(2);
+        self.trim_to_max();
+    }
+
+    fn trim_to_max(&mut self) {
+        while self.data.len() > self.max_samples {
+            self.data.pop_front();
+        }
+    }
+
+    fn push_samples(&mut self, samples: &[i16]) {
+        let samples = &samples[..samples.len() & !1];
+        if samples.is_empty() {
+            return;
+        }
+
+        if samples.len() >= self.max_samples {
+            self.data.clear();
+            self.data.extend(samples[samples.len() - self.max_samples..].iter().copied());
+            return;
+        }
+
+        let overflow = self.data.len().saturating_add(samples.len()).saturating_sub(self.max_samples);
+        for _ in 0..overflow {
+            self.data.pop_front();
+        }
+
+        self.data.extend(samples.iter().copied());
+    }
+
+    fn pop_into(&mut self, out: &mut [i16]) -> usize {
+        let count = out.len().min(self.data.len()) & !1;
+        for slot in out.iter_mut().take(count) {
+            *slot = self.data.pop_front().expect("audio buffer length changed unexpectedly");
+        }
+        count
+    }
+}
+
 impl ThreadedSuperShuckieCore {
     /// Wrap the given `core`.
     pub fn new(emulator_core: Box<dyn EmulatorCore>) -> Self {
         let screens = Arc::new(Mutex::new(emulator_core.get_screens().to_vec()));
         let (sender, receiver) = channel();
         let (sender_close, receiver_close) = channel();
+        let audio_buffer = Arc::new(Mutex::new(AudioBuffer::new(9600)));
+        let audio_sample_rate = Arc::new(AtomicU32::new(0));
 
         let playback_total_frames = 0;
         let playback_total_milliseconds = TimestampMillis(0);
@@ -76,6 +133,8 @@ impl ThreadedSuperShuckieCore {
             let replay_counters = replay_counters.clone();
             let playback_paused = playback_paused.clone();
             let replay_stalled = replay_stalled.clone();
+            let audio_buffer = audio_buffer.clone();
+            let audio_sample_rate = audio_sample_rate.clone();
             let _ = std::thread::Builder::new().name("ThreadedSuperShuckieCore".to_owned()).spawn(move || {
                 ThreadedSuperShuckieCoreThread {
                     screens,
@@ -94,7 +153,9 @@ impl ThreadedSuperShuckieCore {
                     replay_stalled,
                     playback_frozen: false,
                     freezes: BTreeMap::new(),
-                    playback_paused
+                    playback_paused,
+                    audio_buffer,
+                    audio_sample_rate,
                 }.run_thread();
             });
         }
@@ -112,8 +173,24 @@ impl ThreadedSuperShuckieCore {
             desired_replay_frame,
             delta_replay_frames,
             playback_paused,
-            replay_stalled
+            replay_stalled,
+            audio_buffer,
+            audio_sample_rate,
         }
+    }
+
+    /// Get the audio sample rate, if supported.
+    pub fn audio_sample_rate(&self) -> Option<u32> {
+        let rate = self.audio_sample_rate.load(Ordering::Relaxed);
+        if rate == 0 { None } else { Some(rate) }
+    }
+
+    /// Read interleaved stereo audio samples into `out`.
+    ///
+    /// Returns the number of samples written.
+    pub fn read_audio(&self, out: &mut [i16]) -> usize {
+        let mut lock = self.audio_buffer.lock().expect("audio mutex is poisoned");
+        lock.pop_into(out)
     }
 
     /// Get the elapsed time.
@@ -468,6 +545,8 @@ struct ThreadedSuperShuckieCoreThread {
 
     freezes: BTreeMap<u64, ByteVec>,
     replay_stalled: Arc<AtomicBool>,
+    audio_buffer: Arc<Mutex<AudioBuffer>>,
+    audio_sample_rate: Arc<AtomicU32>,
 }
 
 impl ThreadedSuperShuckieCoreThread {
@@ -492,6 +571,7 @@ impl ThreadedSuperShuckieCoreThread {
             if self.is_running() {
                 if !self.playback_frozen {
                     self.core.run();
+                    self.pull_audio();
                 }
             }
             else if self.core.replay_player.is_none() {
@@ -511,6 +591,40 @@ impl ThreadedSuperShuckieCoreThread {
         self.pokeabyte_integration = None;
 
         let _ = self.sender_close.send(());
+    }
+
+    fn pull_audio(&mut self) {
+        const CHUNK_FRAMES: usize = 1024;
+
+        let Some(rate) = self.core.audio_sample_rate() else {
+            return;
+        };
+        self.audio_sample_rate.store(rate, Ordering::Relaxed);
+        if let Ok(mut buf) = self.audio_buffer.lock() {
+            let max_samples = ((rate as usize) * 2 * 50 / 1000).max(CHUNK_FRAMES * 2);
+            buf.set_max_samples(max_samples);
+        }
+
+        let mut available = self.core.audio_available_samples();
+        if available == 0 {
+            return;
+        }
+
+        let mut temp = [0i16; CHUNK_FRAMES * 2];
+
+        while available > 0 {
+            let frames = available.min(CHUNK_FRAMES);
+            let samples_len = frames * 2;
+            let read_frames = self.core.read_audio(&mut temp[..samples_len]);
+            if read_frames == 0 {
+                break;
+            }
+            let read_samples = read_frames * 2;
+            if let Ok(mut buf) = self.audio_buffer.lock() {
+                buf.push_samples(&temp[..read_samples]);
+            }
+            available = available.saturating_sub(read_frames);
+        }
     }
 
     fn check_if_replay_stalled(&mut self) {

--- a/supershuckie-frontend-c/include/supershuckie/frontend.h
+++ b/supershuckie-frontend-c/include/supershuckie/frontend.h
@@ -134,6 +134,18 @@ void supershuckie_frontend_set_paused(struct SuperShuckieFrontendRaw *frontend, 
 void supershuckie_frontend_force_refresh_screens(struct SuperShuckieFrontendRaw *frontend);
 
 /**
+ * Get the audio sample rate, or 0 if audio is unsupported.
+ */
+uint32_t supershuckie_frontend_get_audio_sample_rate(const struct SuperShuckieFrontendRaw *frontend);
+
+/**
+ * Read interleaved stereo audio samples into `out`.
+ *
+ * Returns the number of samples written.
+ */
+size_t supershuckie_frontend_read_audio(struct SuperShuckieFrontendRaw *frontend, int16_t *out, size_t samples);
+
+/**
  * Set the video scale.
  *
  * If scale is 0, it will default to 1.

--- a/supershuckie-frontend-c/src/frontend.rs
+++ b/supershuckie-frontend-c/src/frontend.rs
@@ -218,6 +218,26 @@ pub unsafe extern "C" fn supershuckie_frontend_force_refresh_screens(
 }
 
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn supershuckie_frontend_get_audio_sample_rate(
+    frontend: &SuperShuckieFrontend
+) -> u32 {
+    frontend.audio_sample_rate()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn supershuckie_frontend_read_audio(
+    frontend: &SuperShuckieFrontend,
+    out: *mut i16,
+    samples: usize
+) -> usize {
+    if out.is_null() || samples == 0 {
+        return 0;
+    }
+    let slice = unsafe { std::slice::from_raw_parts_mut(out, samples) };
+    frontend.read_audio(slice)
+}
+
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn supershuckie_frontend_set_video_scale(
     frontend: &mut SuperShuckieFrontend,
     scale: u8

--- a/supershuckie-frontend/src/lib.rs
+++ b/supershuckie-frontend/src/lib.rs
@@ -210,6 +210,18 @@ impl SuperShuckieFrontend {
         panic!("Out of controller indices");
     }
 
+    /// Get the audio sample rate, or 0 if audio is unsupported.
+    pub fn audio_sample_rate(&self) -> u32 {
+        self.core.audio_sample_rate().unwrap_or(0)
+    }
+
+    /// Read interleaved stereo audio samples into `out`.
+    ///
+    /// Returns the number of samples written.
+    pub fn read_audio(&self, out: &mut [i16]) -> usize {
+        self.core.read_audio(out)
+    }
+
     /// Get a list of all connected controllers.
     pub fn get_connected_controllers(&self) -> Vec<UTF8CString> {
         self.connected_controllers.iter().map(|(_,v)| v.to_owned()).collect()

--- a/supershuckie-qt/src/main.cpp
+++ b/supershuckie-qt/src/main.cpp
@@ -11,7 +11,7 @@
 #include "theme.hpp"
 
 int main(int argc, char **argv) {
-    SDL_Init(SDL_INIT_EVENTS | SDL_INIT_GAMEPAD | SDL_INIT_VIDEO);
+    SDL_Init(SDL_INIT_AUDIO | SDL_INIT_EVENTS | SDL_INIT_GAMEPAD | SDL_INIT_VIDEO);
 
     QCoreApplication::setOrganizationName("SnowyMouse");
     QCoreApplication::setApplicationName("SuperShuckie");

--- a/supershuckie-qt/src/main_window.cpp
+++ b/supershuckie-qt/src/main_window.cpp
@@ -1,6 +1,8 @@
 // FIXME: we need this to be somewhere else
 #define SUPERSHUCKIE_VERSION "0.4.9"
 
+#include <algorithm>
+#include <cstdint>
 #include <cstdio>
 #include <QLayout>
 #include <SDL3/SDL.h>
@@ -9,6 +11,7 @@
 #include <QStatusBar>
 #include <QFileDialog>
 #include <QFontDatabase>
+#include <QInputDialog>
 #include <QLabel>
 #include <QStandardPaths>
 #include <QDesktopServices>
@@ -39,6 +42,8 @@ static const char *WINDOW_XY = "qt__window_xy";
 static const char *DISPLAY_STATUS_BAR = "qt__display_status_bar";
 static const char *KEYBOARD_REPLAY_CONTROLS_DISABLED = "qt__replay_controls_disabled";
 static const char *HORIZONTAL_NDS = "qt__horizontal_nds";
+static const char *AUDIO_ENABLED = "qt__audio_enabled";
+static const char *AUDIO_VOLUME = "qt__audio_volume";
 
 class SuperShuckie64::SuperShuckieTimestamp: public QWidget {
 public:
@@ -209,6 +214,19 @@ MainWindow::MainWindow(): QMainWindow() {
         this->keyboard_replay_controls->setChecked(false);
     }
 
+    const char *audio_enabled_setting = supershuckie_frontend_get_custom_setting(this->frontend, AUDIO_ENABLED);
+    if(audio_enabled_setting != nullptr && audio_enabled_setting[0] == '0') {
+        this->audio_enabled = false;
+    }
+
+    const char *audio_volume_setting = supershuckie_frontend_get_custom_setting(this->frontend, AUDIO_VOLUME);
+    if(audio_volume_setting != nullptr) {
+        int volume = 100;
+        if(std::sscanf(audio_volume_setting, "%d", &volume) == 1) {
+            this->audio_volume = std::clamp(volume, 0, 100);
+        }
+    }
+
     const char *xy = supershuckie_frontend_get_custom_setting(this->frontend, WINDOW_XY);
     if(xy != nullptr) {
         int x;
@@ -231,6 +249,8 @@ MainWindow::MainWindow(): QMainWindow() {
     this->auto_resync_keyframes_in_replay->setChecked(supershuckie_frontend_get_auto_resync_keyframes_in_replay(this->frontend));
     this->disable_save_states_when_recording->setChecked(supershuckie_frontend_get_disable_save_states_when_recording(this->frontend));
     this->disable_speed_changes_when_recording->setChecked(supershuckie_frontend_get_disable_speed_changes_when_recording(this->frontend));
+    this->enable_audio->setChecked(this->audio_enabled);
+    this->refresh_audio_menu_text();
 
     this->sdl.frontend = this->frontend;
     this->render_widget->setFocus(Qt::OtherFocusReason);
@@ -349,6 +369,9 @@ void MainWindow::tick() {
     if(!supershuckie_frontend_tick(this->frontend, buf, sizeof(buf))) {
         DISPLAY_ERROR_DIALOG("Error!", "%s", buf);
     }
+
+    this->refresh_audio_stream();
+    this->pump_audio();
 
     this->pause->setChecked(supershuckie_frontend_is_paused(this->frontend));
 
@@ -628,6 +651,15 @@ void MainWindow::set_up_settings_menu() {
         action->setCheckable(true);
     }
 
+    auto *audio_settings = this->settings_menu->addMenu("Audio settings");
+
+    this->enable_audio = audio_settings->addAction("Enable sound");
+    this->enable_audio->setCheckable(true);
+    connect(this->enable_audio, SIGNAL(triggered()), this, SLOT(do_toggle_audio()));
+
+    this->set_audio_volume = audio_settings->addAction("Volume...");
+    connect(this->set_audio_volume, SIGNAL(triggered()), this, SLOT(do_set_audio_volume()));
+
     this->settings_menu->addSeparator();
 
     this->game_boy_settings = this->settings_menu->addMenu("Game Boy settings");
@@ -779,6 +811,8 @@ void MainWindow::do_open_rom() {
 
 void MainWindow::load_rom(const std::filesystem::path &path) {
     char error[256] = "";
+    this->destroy_audio_stream();
+    this->audio_failed_sample_rate = 0;
 
     auto path_string = path.string();
     if(!supershuckie_frontend_load_rom(this->frontend, path.string().c_str(), error, sizeof(error))) {
@@ -793,11 +827,15 @@ void MainWindow::load_rom(const char *path) {
 }
 
 void MainWindow::do_close_rom() {
+    this->destroy_audio_stream();
+    this->audio_failed_sample_rate = 0;
     supershuckie_frontend_close_rom(this->frontend);
     supershuckie_frontend_set_paused(this->frontend, false);
 }
 
 void MainWindow::do_unload_rom() {
+    this->destroy_audio_stream();
+    this->audio_failed_sample_rate = 0;
     supershuckie_frontend_unload_rom(this->frontend);
     supershuckie_frontend_set_paused(this->frontend, false);
 }
@@ -837,6 +875,8 @@ void MainWindow::do_save_new_game() {
 }
 
 void MainWindow::do_reset_console() {
+    this->destroy_audio_stream();
+    this->audio_failed_sample_rate = 0;
     supershuckie_frontend_hard_reset_console(this->frontend);
 }
 
@@ -880,6 +920,7 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 }
 
 MainWindow::~MainWindow() {
+    this->destroy_audio_stream();
     if(this->frontend) {
         supershuckie_frontend_free(this->frontend);
         this->frontend = nullptr;
@@ -1041,6 +1082,42 @@ void MainWindow::do_toggle_status_bar() {
     this->refresh_title();
 }
 
+void MainWindow::do_toggle_audio() {
+    this->audio_enabled = this->enable_audio->isChecked();
+    supershuckie_frontend_set_custom_setting(this->frontend, AUDIO_ENABLED, this->audio_enabled ? "1" : "0");
+    this->audio_failed_sample_rate = 0;
+
+    if(!this->audio_enabled) {
+        this->destroy_audio_stream();
+    }
+}
+
+void MainWindow::do_set_audio_volume() {
+    bool ok = false;
+    int volume = QInputDialog::getInt(
+        this,
+        "Audio volume",
+        "Volume percentage:",
+        this->audio_volume,
+        0,
+        100,
+        5,
+        &ok
+    );
+
+    if(!ok) {
+        return;
+    }
+
+    this->audio_volume = volume;
+    this->refresh_audio_menu_text();
+    this->apply_audio_gain();
+
+    char buf[16];
+    std::snprintf(buf, sizeof(buf), "%d", this->audio_volume);
+    supershuckie_frontend_set_custom_setting(this->frontend, AUDIO_VOLUME, buf);
+}
+
 void MainWindow::do_toggle_pokeabyte() {
     char err[256];
 
@@ -1143,6 +1220,8 @@ void MainWindow::do_toggle_horizontal_nds() {
 }
 
 void MainWindow::do_toggle_nds_jit() {
+    this->destroy_audio_stream();
+    this->audio_failed_sample_rate = 0;
     supershuckie_frontend_set_nds_jit(this->frontend, this->nds_jit->isChecked());
 }
 
@@ -1169,7 +1248,124 @@ void MainWindow::do_clear_recent_roms() {
 }
 
 void MainWindow::do_reload_core() {
+    this->destroy_audio_stream();
+    this->audio_failed_sample_rate = 0;
     supershuckie_frontend_reload_core(this->frontend);
+}
+
+void MainWindow::refresh_audio_stream() {
+    if(this->frontend == nullptr) {
+        this->destroy_audio_stream();
+        this->audio_failed_sample_rate = 0;
+        return;
+    }
+
+    if(!this->audio_enabled) {
+        this->destroy_audio_stream();
+        return;
+    }
+
+    std::uint32_t desired_sample_rate = supershuckie_frontend_get_audio_sample_rate(this->frontend);
+    if(desired_sample_rate == 0) {
+        this->destroy_audio_stream();
+        this->audio_failed_sample_rate = 0;
+        return;
+    }
+
+    if(this->audio_stream != nullptr && this->audio_sample_rate == desired_sample_rate) {
+        return;
+    }
+
+    if(this->audio_stream == nullptr && this->audio_failed_sample_rate == desired_sample_rate) {
+        return;
+    }
+
+    this->destroy_audio_stream();
+
+    SDL_AudioSpec spec = {};
+    spec.format = SDL_AUDIO_S16;
+    spec.channels = 2;
+    spec.freq = static_cast<int>(desired_sample_rate);
+
+    this->audio_stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, nullptr, nullptr);
+    if(this->audio_stream == nullptr) {
+        std::fprintf(stderr, "Failed to open audio stream: %s\n", SDL_GetError());
+        this->audio_failed_sample_rate = desired_sample_rate;
+        return;
+    }
+
+    if(!SDL_ResumeAudioStreamDevice(this->audio_stream)) {
+        std::fprintf(stderr, "Failed to resume audio stream: %s\n", SDL_GetError());
+        this->destroy_audio_stream();
+        this->audio_failed_sample_rate = desired_sample_rate;
+        return;
+    }
+
+    this->audio_sample_rate = desired_sample_rate;
+    this->audio_failed_sample_rate = 0;
+    this->apply_audio_gain();
+}
+
+void MainWindow::pump_audio() {
+    if(this->audio_stream == nullptr || this->frontend == nullptr || this->audio_sample_rate == 0) {
+        return;
+    }
+
+    int queued = SDL_GetAudioStreamQueued(this->audio_stream);
+    if(queued < 0) {
+        std::fprintf(stderr, "Failed to query queued audio: %s\n", SDL_GetError());
+        return;
+    }
+
+    constexpr int CHANNELS = 2;
+    constexpr int CHUNK_FRAMES = 1024;
+    constexpr int TARGET_BUFFER_MS = 25;
+    constexpr int BYTES_PER_SAMPLE = sizeof(std::int16_t);
+    const int target_bytes = static_cast<int>(
+        (static_cast<std::uint64_t>(this->audio_sample_rate) * CHANNELS * BYTES_PER_SAMPLE * TARGET_BUFFER_MS) / 1000
+    );
+
+    while(queued < target_bytes) {
+        std::int16_t samples[CHUNK_FRAMES * CHANNELS];
+        std::size_t read = supershuckie_frontend_read_audio(this->frontend, samples, sizeof(samples) / sizeof(samples[0]));
+        read &= ~static_cast<std::size_t>(1);
+        if(read == 0) {
+            break;
+        }
+
+        int bytes = static_cast<int>(read * sizeof(samples[0]));
+        if(!SDL_PutAudioStreamData(this->audio_stream, samples, bytes)) {
+            std::fprintf(stderr, "Failed to queue audio: %s\n", SDL_GetError());
+            this->destroy_audio_stream();
+            return;
+        }
+
+        queued += bytes;
+    }
+}
+
+void MainWindow::destroy_audio_stream() {
+    if(this->audio_stream != nullptr) {
+        SDL_DestroyAudioStream(this->audio_stream);
+        this->audio_stream = nullptr;
+    }
+    this->audio_sample_rate = 0;
+}
+
+void MainWindow::apply_audio_gain() {
+    if(this->audio_stream == nullptr) {
+        return;
+    }
+
+    if(!SDL_SetAudioStreamGain(this->audio_stream, static_cast<float>(this->audio_volume) / 100.0f)) {
+        std::fprintf(stderr, "Failed to set audio gain: %s\n", SDL_GetError());
+    }
+}
+
+void MainWindow::refresh_audio_menu_text() {
+    if(this->set_audio_volume != nullptr) {
+        this->set_audio_volume->setText(QString("Volume... (%1%)").arg(this->audio_volume));
+    }
 }
 
 void MainWindow::do_toggle_external_commands() {

--- a/supershuckie-qt/src/main_window.hpp
+++ b/supershuckie-qt/src/main_window.hpp
@@ -13,6 +13,7 @@ class QMenu;
 class QAction;
 class QCloseEvent;
 class QLabel;
+struct SDL_AudioStream;
 
 namespace SuperShuckie64 {
 
@@ -122,6 +123,8 @@ private:
 
     QAction *use_number_row_for_quick_slots;
     QAction *show_status_bar;
+    QAction *enable_audio;
+    QAction *set_audio_volume;
     QAction *enable_pokeabyte_integration;
     QAction *enable_external_commands;
 
@@ -178,6 +181,16 @@ private:
     void stop_timer();
     void start_timer();
     int timer_stack = 0;
+    void refresh_audio_stream();
+    void pump_audio();
+    void destroy_audio_stream();
+    void apply_audio_gain();
+    void refresh_audio_menu_text();
+    SDL_AudioStream *audio_stream = nullptr;
+    std::uint32_t audio_sample_rate = 0;
+    std::uint32_t audio_failed_sample_rate = 0;
+    bool audio_enabled = true;
+    int audio_volume = 100;
 
     QString app_dir;
 
@@ -201,6 +214,8 @@ private slots:
     void do_undo_load_save_state();
     void do_redo_load_save_state();
     void do_toggle_status_bar();
+    void do_toggle_audio();
+    void do_set_audio_volume();
     void do_toggle_pokeabyte();
     void do_toggle_stop_replay_on_input();
     void do_open_controls_settings_dialog() noexcept;


### PR DESCRIPTION
## Summary

This PR adds end-to-end audio output for the emulator cores and exposes basic audio controls in the Qt frontend.

## What changed

- added audio read/sample-rate plumbing for mGBA and melonDS
- buffered audio in `ThreadedSuperShuckieCore`
- exposed audio read APIs through `supershuckie-frontend` and the C FFI layer
- added SDL3 audio playback in the Qt app
- added `Settings -> Audio settings` with:
  - `Enable sound`
  - `Volume...`
- persisted the audio enable/volume settings through existing custom settings storage

## Notes

- audio buffering was trimmed to keep latency low instead of preserving a large backlog
- stereo sample counts are forced to whole frames before queuing to SDL
- this is scoped to emulator audio output and Qt audio controls only

## Verification

- `CCACHE_DIR=/tmp/ccache cmake --build build-ninja-m1 -j4` passed
- tested interactively for working audio output, low-latency playback, and basic enable/volume control behavior
